### PR TITLE
Fix typo: how to use*

### DIFF
--- a/docs/smart-chain/wallet/extension/ledger.md
+++ b/docs/smart-chain/wallet/extension/ledger.md
@@ -1,4 +1,4 @@
-# How to usd Ledger with Binance Extension Wallet
+# How to use Ledger with Binance Extension Wallet
 Binance Extension Wallet v1.121.1 is released and verified on **Firefox and Chrome** with Ledger Nano S
 
 ## **Connect to Ledger Nano S Hardware Wallet**


### PR DESCRIPTION
On the Ledger wallet page there's a typo; it says "how to usd" instead of "how to use".

Affected page: https://docs.binance.org/smart-chain/wallet/extension/ledger.html