### PR TITLE
Fix broken github link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -252,7 +252,7 @@ repo_url: 'https://github.com/binance-chain/docs-site'
 extra:
   social:
     - type: 'github'
-      link: 'binance-chain/docs-site'
+      link: 'https://github.com/binance-chain/docs-site'
     - type: 'twitter'
       link: 'https://twitter.com/binancechain'
     - type: 'website'


### PR DESCRIPTION
When we click github badge bottom (footer) of the site link is broken.

Current Redicret page: https://docs.binance.org/binance-chain/docs-site
Should be redirect page: https://github.com/binance-chain/docs-site

![image](https://user-images.githubusercontent.com/37574822/117602204-0eb14080-b18b-11eb-9c62-4101c5ad81f9.png)
