### PR TITLE
Fixed mainnet chainID

### DIFF
--- a/docs/smart-chain/guides/concepts/genesis.md
+++ b/docs/smart-chain/guides/concepts/genesis.md
@@ -17,7 +17,7 @@ Genesis Link for Chapel Testnet: <https://github.com/binance-chain/bsc/releases/
 
 * **chainId**
 
-**56** for main-net and **96** for test-net.  To compatible with third part service that already supports Ethereum, we’d better not use network id that Ethereum ecology that already used.  The network id of test-net should be distinct from main-net.
+**56** for main-net and **97** for test-net.  To compatible with third part service that already supports Ethereum, we’d better not use network id that Ethereum ecology that already used.  The network id of test-net should be distinct from main-net.
 
 
 * **period**

--- a/docs/smart-chain/guides/concepts/genesis.md
+++ b/docs/smart-chain/guides/concepts/genesis.md
@@ -17,7 +17,7 @@ Genesis Link for Chapel Testnet: <https://github.com/binance-chain/bsc/releases/
 
 * **chainId**
 
-**66** for main-net and **96** for test-net.  To compatible with third part service that already supports Ethereum, we’d better not use network id that Ethereum ecology that already used.  The network id of test-net should be distinct from main-net.
+**56** for main-net and **96** for test-net.  To compatible with third part service that already supports Ethereum, we’d better not use network id that Ethereum ecology that already used.  The network id of test-net should be distinct from main-net.
 
 
 * **period**


### PR DESCRIPTION
### What does this PR do?

1. The chainID was referring to OKExChain mainnet `66` instead of BSC Mainnet `56`